### PR TITLE
Separate development and production settings for carrierwave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,3 @@
 .env
 db/fixtures
 public/uploads
-
-db/fixtures

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -5,7 +5,13 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   # Choose what kind of storage to use for this uploader:
   # storage :file
-  storage :fog
+  if Rails.env.development?
+    storage :file
+  elsif Rails.env.test?
+    storage :file
+  else
+    storage :fog
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -2,16 +2,18 @@ require 'carrierwave/storage/abstract'
 require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
-CarrierWave.configure do |config|
-  config.storage = :fog
-  config.fog_provider = 'fog/aws'
-  config.fog_credentials = {
-    provider: 'AWS',
-    aws_access_key_id: Rails.application.secrets.aws_access_key_id,
-    aws_secret_access_key: Rails.application.secrets.aws_secret_access_key,
-    region: 'ap-northeast-1'
-  }
+if Rails.env.production?
+  CarrierWave.configure do |config|
+    config.storage = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: Rails.application.secrets.aws_access_key_id,
+      aws_secret_access_key: Rails.application.secrets.aws_secret_access_key,
+      region: 'ap-northeast-1'
+    }
 
-  config.fog_directory  = 'freemarketsample50c'
-  config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/freemarketsample50c'
+    config.fog_directory  = 'freemarketsample50c'
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/freemarketsample50c'
+  end
 end


### PR DESCRIPTION
# WHAT
・画像アップロード先、参照先の設定を開発と本番で分ける
# WHY
・開発の場合はS3にアクセスする必要がないため
・ダミーデータ（画像）の登録できないため